### PR TITLE
Fixes #21: Use 'this' for rendering component named arguments

### DIFF
--- a/addon/components/ember-notifier-notification/content/template.hbs
+++ b/addon/components/ember-notifier-notification/content/template.hbs
@@ -6,9 +6,9 @@
     setOption=setOption}}
 {{else}}
   <p class="ember-notifier-title">
-    {{title}}
+    {{this.title}}
   </p>
   <p class="ember-notifier-message">
-    {{message}}
+    {{this.message}}
   </p>
 {{/if}}

--- a/addon/components/ember-notifier-notification/icon/template.hbs
+++ b/addon/components/ember-notifier-notification/icon/template.hbs
@@ -2,6 +2,6 @@
   {{#if hasBlock}}
     {{yield}}
   {{else}}
-    <i class={{icon}}></i>
+    <i class={{this.icon}}></i>
   {{/if}}
 </span>


### PR DESCRIPTION
Leaflet defines an `{{icon}}` helper which gets called instead of rendering the `{{icon}}` property value in the icon template. Current solution is `{{this.icon}}` and when support for `ember-source<3.1` is dropped switch to [named arguments](https://emberjs.com/blog/2018/04/13/ember-3-1-released.html#toc_named-arguments-1-of-4) `{{@icon}}`.

